### PR TITLE
Tool groups

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -19,7 +19,7 @@ end
 minetest.register_craftitem("obsidianstuff:ingot", {
     description = S("Obsidion Ingot"),
     inventory_image = "obsidianstuff_ingot.png",
-    
+
 })
 
 minetest.register_craft({
@@ -35,83 +35,83 @@ minetest.register_craft({
 minetest.register_tool("obsidianstuff:sword", {
     description = S("Obsidian Sword"),
     inventory_image = "obsidianstuff_sword.png",
-    
     tool_capabilities = {
-		full_punch_interval = 0.6,
-		max_drop_level = 1,
-		groupcaps = {
-			snappy = {
-				times = {1.7, 0.7, 0.25},
-				uses = 50,
-				maxlevel = 3
-			},
-		},
-		damage_groups = {fleshy = 10, burns = 0},
-    },
-})
-
-
-
-
-    minetest.register_tool("obsidianstuff:pick", {
-        description = S("Obsidian Pickaxe"),
-        inventory_image = "obsidianstuff_pick.png",
-       
-        tool_capabilities = {
-
-            full_punch_interval = 0.7,
-            max_drop_level = 3,
-            groupcaps={
-                cracky = {
-                    times = {[1] = 1.8, [2] = 0.8, [3] = 0.40},
-                    uses = 40,
-                    maxlevel = 3
-                },
-            },
-            damage_groups = {fleshy = 6, burns = 0},
+      full_punch_interval = 0.6,
+      max_drop_level = 1,
+		  groupcaps = {
+        snappy = {
+          times = {1.7, 0.7, 0.25},
+          uses = 50,
+          maxlevel = 3
         },
-    })
+      },
+      damage_groups = {fleshy = 10, burns = 0},
+    },
+    sound = {breaks = "default_tool_breaks"},
+    groups = {sword = 1}
+  })
 
 
-
-
+minetest.register_tool("obsidianstuff:pick", {
+    description = S("Obsidian Pickaxe"),
+    inventory_image = "obsidianstuff_pick.png",
+    tool_capabilities = {
+      full_punch_interval = 0.7,
+      max_drop_level = 3,
+      groupcaps={
+        cracky = {
+          times = {[1] = 1.8, [2] = 0.8, [3] = 0.40},
+          uses = 40,
+          maxlevel = 3
+        },
+      },
+      damage_groups = {fleshy = 6, burns = 0},
+    },
+    sound = {breaks = "default_tool_breaks"},
+    groups = {pickaxe = 1}
+  })
 
 
 minetest.register_tool("obsidianstuff:shovel", {
     description = S("Obsidian Shovel"),
     inventory_image = "obsidianstuff_shovel.png",
     wield_image = "obsidianstuff_shovel.png^[transformR90",
-
     tool_capabilities = {
-		full_punch_interval = 1.0,
-		max_drop_level=1,
-		groupcaps={
-			crumbly = {times={[1]=1.10, [2]=0.50, [3]=0.30}, uses=30, maxlevel=3},
-		},
-		damage_groups = {fleshy=4},
-	},
+      full_punch_interval = 1.0,
+      max_drop_level=1,
+      groupcaps={
+        crumbly = {
+          times={[1]=1.10, [2]=0.50, [3]=0.30},
+          uses=30,
+          maxlevel=3
+        },
+      },
+      damage_groups = {fleshy=4},
+    },
     on_place = obsidianstuff.tool_fire_func,
     sound = {breaks = "default_tool_breaks"},
-})
+    groups = {shovel = 1}
+  })
+
 
 minetest.register_tool("obsidianstuff:axe", {
     description = S("Obsidian Axe"),
     inventory_image = "obsidianstuff_axe.png",
-
     tool_capabilities = {
-		full_punch_interval = 0.8,
-		max_drop_level = 1,
-		groupcaps = {
-			choppy = {
-				times = {[1] = 2.00, [2] = 0.80, [3] = 0.40},
-				uses = 40,
-				maxlevel = 3
-			},
-		},
-		damage_groups = {fleshy = 7, burns = 0},
-	},
-
-})
+      full_punch_interval = 0.8,
+      max_drop_level = 1,
+      groupcaps = {
+        choppy = {
+          times = {[1] = 2.00, [2] = 0.80, [3] = 0.40},
+          uses = 40,
+          maxlevel = 3
+        },
+      },
+      damage_groups = {fleshy = 7, burns = 0},
+    },
+    sound = {breaks = "default_tool_breaks"},
+    groups = {axe = 1}
+  })
 --
 -- Tool Crafts
 --
@@ -317,4 +317,3 @@ if minetest.get_modpath("toolranks") then
         after_use = toolranks.new_afteruse
     })
 end
-


### PR DESCRIPTION
Added tool groups like {pickaxe=1} to be useable in other mods.
Note that those groups appear also in the default mod from the MTG (and just make sense).

My main motivation was that this is needed for enchanting in the mod "x_enchanting" https://bitbucket.org/minetest_gamers/x_enchanting/src/master/

I also added the breaking sound for all tools and did some re-spacing.
